### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = ""

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Stupidly easy to use, small footprint **Policy as Code** subsecond command-line 
 
 [![Latest release](https://img.shields.io/badge/release-MVP%20ONE-blue)](https://github.com/xfhg/intercept/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/xfhg/intercept)](https://goreportcard.com/report/github.com/xfhg/intercept)
+[![Run on Repl.it](https://repl.it/badge/github/xfhg/intercept)](https://repl.it/github/xfhg/intercept)
 
 ## How it works
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).