### PR TITLE
Fix #145

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -100,11 +100,11 @@ var apiCmd = &cobra.Command{
 				}
 
 			}
-
-			GenerateSarif("api")
-			GenerateComplianceSarif(apiCompliance)
-			GenerateApiSARIF()
-
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("api")
+				GenerateComplianceSarif(apiCompliance)
+				GenerateApiSARIF()
+			}
 		} else {
 
 			values := make(chan Rule, len(rules.Rules))

--- a/cmd/assure.go
+++ b/cmd/assure.go
@@ -139,10 +139,11 @@ var assureCmd = &cobra.Command{
 				_ = os.Remove(searchPatternFile)
 
 			}
-
-			GenerateSarif("assure")
-			GenerateComplianceSarif(aCompliance)
-			GenerateAssureSARIF()
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("assure")
+				GenerateComplianceSarif(aCompliance)
+				GenerateAssureSARIF()
+			}
 
 		} else {
 

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -151,8 +151,9 @@ var auditCmd = &cobra.Command{
 				_ = os.Remove(searchPatternFile)
 
 			}
-
-			GenerateSarif("audit")
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("audit")
+			}
 
 			fmt.Println("│")
 			fmt.Println("│")

--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -152,8 +152,9 @@ var collectCmd = &cobra.Command{
 				_ = os.Remove(searchPatternFile)
 
 			}
-
-			GenerateSarif("collect")
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("collect")
+			}
 
 			fmt.Println("│")
 			fmt.Println("│")

--- a/cmd/core_format.go
+++ b/cmd/core_format.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/itchyny/gojq"
 	"github.com/lens-vm/jsonmerge"
@@ -452,7 +454,7 @@ func GenerateComplianceSarif(results InterceptComplianceOutput) {
 
 	report.AddRun(run)
 
-	sarifOutputFilename := strings.Join([]string{"intercept.", strings.ToLower(results[0].RuleType), ".sarif.json"}, "")
+	sarifOutputFilename := strings.Join([]string{"intercept.", strings.ToLower(results[0].RuleType), ".", strconv.FormatInt(time.Now().UnixNano(), 10), ".sarif.json"}, "")
 
 	if FileExists(sarifOutputFilename) {
 		_ = os.Remove(sarifOutputFilename)

--- a/cmd/core_format.go
+++ b/cmd/core_format.go
@@ -455,10 +455,12 @@ func GenerateComplianceSarif(results InterceptComplianceOutput) {
 	report.AddRun(run)
 
 	sarifOutputFilename := strings.Join([]string{"intercept.", strings.ToLower(results[0].RuleType), ".", strconv.FormatInt(time.Now().UnixNano(), 10), ".sarif.json"}, "")
-
-	if FileExists(sarifOutputFilename) {
-		_ = os.Remove(sarifOutputFilename)
-	}
+	// Commenting existing check to see if the file exists and the subsequent removal as it is not required for unique file names
+	/*
+		if FileExists(sarifOutputFilename) {
+			_ = os.Remove(sarifOutputFilename)
+		}
+	*/
 	if findings > 0 {
 		if err := report.WriteFile(sarifOutputFilename); err != nil {
 			LogError(err)

--- a/cmd/goss.go
+++ b/cmd/goss.go
@@ -134,8 +134,9 @@ var gossCmd = &cobra.Command{
 				}
 
 			}
-
-			GenerateSarif("scan")
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("scan")
+			}
 
 			fmt.Println("│")
 			fmt.Println("│")

--- a/cmd/ini.go
+++ b/cmd/ini.go
@@ -355,8 +355,9 @@ var iniCmd = &cobra.Command{
 
 		}
 
-		GenerateComplianceSarif(oiCompliance)
-
+		if outputType == "full" || outputType == "sarif" {
+			GenerateComplianceSarif(oiCompliance)
+		}
 		fmt.Println("│")
 		fmt.Println("│")
 		fmt.Println("│")

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -353,8 +353,9 @@ var jsonCmd = &cobra.Command{
 			wg.Wait() // Wait for all goroutines to finish
 
 		}
-
-		GenerateComplianceSarif(oCompliance)
+		if outputType == "full" || outputType == "sarif" {
+			GenerateComplianceSarif(oCompliance)
+		}
 
 		fmt.Println("│")
 		fmt.Println("│")

--- a/cmd/re.go
+++ b/cmd/re.go
@@ -153,9 +153,10 @@ var regoCmd = &cobra.Command{
 				// _ = os.Remove(searchPatternFile)
 
 			}
-
-			GenerateSarif("rego")
-			GenerateComplianceSarif(rCompliance)
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("rego")
+				GenerateComplianceSarif(rCompliance)
+			}
 
 			fmt.Println("│")
 			fmt.Println("│")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -137,8 +137,9 @@ var scanCmd = &cobra.Command{
 				_ = os.Remove(searchPatternFile)
 
 			}
-
-			GenerateSarif("scan")
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("scan")
+			}
 
 			fmt.Println("│")
 			fmt.Println("│")

--- a/cmd/toml.go
+++ b/cmd/toml.go
@@ -354,8 +354,9 @@ var tomlCmd = &cobra.Command{
 			wg.Wait() // Wait for all goroutines to finish
 
 		}
-
-		GenerateComplianceSarif(otCompliance)
+		if outputType == "full" || outputType == "sarif" {
+			GenerateComplianceSarif(otCompliance)
+		}
 
 		fmt.Println("│")
 		fmt.Println("│")

--- a/cmd/turbo.go
+++ b/cmd/turbo.go
@@ -55,7 +55,9 @@ func ripTurbo(rgbin string, pwddir string, scanPath string, policy Rule) {
 
 		} else {
 			ProcessOutput(strings.Join([]string{policy.ID, ".json"}, ""), policy.ID, policy.Type, policy.Name, policy.Description, policy.Error, policy.Solution, policy.Fatal)
-			GenerateSarif("audit")
+			if outputType == "full" || outputType == "sarif" {
+				GenerateSarif("audit")
+			}
 			colorRedBold.Print("│")
 		}
 

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -355,8 +355,9 @@ var yamlCmd = &cobra.Command{
 			wg.Wait() // Wait for all goroutines to finish
 
 		}
-
-		GenerateComplianceSarif(oyCompliance)
+		if outputType == "full" || outputType == "sarif" {
+			GenerateComplianceSarif(oyCompliance)
+		}
 
 		fmt.Println("│")
 		fmt.Println("│")


### PR DESCRIPTION
Sample output files:

intercept.ini.1722519140484311000.sarif.json
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e7cf1c8bc4ab7354feac07c1061ce240e58de58c  | 
|--------|--------|

### Summary:
Fixes issue #145 by appending a UTC nanosecond timestamp to SARIF output filenames in `GenerateComplianceSarif` to ensure unique filenames and prevent overwrites.

**Key points**:
- Fixes issue #145 by appending a UTC nanosecond timestamp to SARIF output filenames in `GenerateComplianceSarif`.
- Ensures unique filenames to prevent overwrites.
- Modified `cmd/core_format.go` to include the timestamp in the filename.
- Commented out the existing file existence check and removal logic as it is no longer needed.
- Affected files: `cmd/api.go`, `cmd/assure.go`, `cmd/audit.go`, `cmd/collect.go`, `cmd/goss.go`, `cmd/ini.go`, `cmd/json.go`, `cmd/re.go`, `cmd/scan.go`, `cmd/toml.go`, `cmd/turbo.go`, `cmd/yaml.go`.
- Example filename format: `intercept.<ruleType>.<timestamp>.sarif.json`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->