### PR TITLE
Fix assure match detection and add coverage for parallel batches

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -116,11 +116,9 @@ func processWithCUE(policy Policy, data []byte, isObserve bool) error {
 			var resultMsg string
 
 			if sarifReport.Runs[0].Invocations[0].Properties.ReportCompliant {
-
-				resultMsg = fmt.Sprintf("🟢 %s : %s", "Compliant")
-
+				resultMsg = "🟢 Compliant"
 			} else {
-				resultMsg = fmt.Sprintf("🔴 %s : %s", "Non Compliant")
+				resultMsg = "🔴 Non Compliant"
 			}
 			storeResultInCache(policy.ID, resultMsg)
 

--- a/cmd/assure_test.go
+++ b/cmd/assure_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestExecuteAssureParallelStatusHandler(t *testing.T) {
+	rgBinary, err := exec.LookPath("rg")
+	if err != nil {
+		t.Fatalf("rg binary not found: %v", err)
+	}
+
+	originalPolicyData := policyData
+	originalOutputDir := outputDir
+	policyData = &PolicyFile{}
+	baseOutputDir := t.TempDir()
+	outputDir = baseOutputDir
+	requiredDirs := []string{"_debug", "_sarif"}
+	for _, dir := range requiredDirs {
+		if err := os.MkdirAll(filepath.Join(outputDir, dir), 0o755); err != nil {
+			t.Fatalf("failed to create %s dir: %v", dir, err)
+		}
+	}
+	t.Cleanup(func() {
+		policyData = originalPolicyData
+		outputDir = originalOutputDir
+	})
+
+	totalFiles := parallelBatchSize + 5
+
+	tests := []struct {
+		name       string
+		matchIndex int
+		wantMatch  bool
+	}{
+		{name: "match", matchIndex: 3, wantMatch: true},
+		{name: "no_match", matchIndex: -1, wantMatch: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			targetDir := filepath.Join(baseOutputDir, tc.name)
+			if err := os.MkdirAll(targetDir, 0o755); err != nil {
+				t.Fatalf("failed to create target dir: %v", err)
+			}
+
+			files := make([]string, 0, totalFiles)
+			for i := 0; i < totalFiles; i++ {
+				filePath := filepath.Join(targetDir, fmt.Sprintf("file_%s_%d.txt", tc.name, i))
+				content := "this file does not contain the pattern"
+				if tc.matchIndex >= 0 && i == tc.matchIndex {
+					content = "this file includes the special pattern"
+				}
+				if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+					t.Fatalf("failed to write test file: %v", err)
+				}
+				files = append(files, filePath)
+			}
+
+			policy := Policy{
+				ID:          fmt.Sprintf("policy-%s", tc.name),
+				FilePattern: "*.txt",
+				Regex:       []string{"special"},
+			}
+
+			var (
+				mu       sync.Mutex
+				statuses []bool
+			)
+			SetPolicyStatusHandler(func(p Policy, matched bool) {
+				mu.Lock()
+				defer mu.Unlock()
+				statuses = append(statuses, matched)
+			})
+			t.Cleanup(func() {
+				SetPolicyStatusHandler(nil)
+			})
+
+			if err := executeAssure(policy, rgBinary, targetDir, files); err != nil {
+				t.Fatalf("executeAssure failed: %v", err)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(statuses) == 0 {
+				t.Fatalf("status handler was not invoked")
+			}
+			got := statuses[len(statuses)-1]
+			if got != tc.wantMatch {
+				t.Fatalf("expected match status %v, got %v", tc.wantMatch, got)
+			}
+		})
+	}
+}

--- a/cmd/rg_executor.go
+++ b/cmd/rg_executor.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sync"
+)
+
+const parallelBatchSize = 25
+
+type ripgrepOutputConsumer func([]byte) error
+
+func runParallelRipgrep(rgPath string, baseArgs []string, files []string, consume ripgrepOutputConsumer) (bool, error) {
+	if len(files) == 0 {
+		return false, nil
+	}
+
+	var (
+		matchesFound bool
+		matchesMu    sync.Mutex
+		wg           sync.WaitGroup
+		errChan      = make(chan error, (len(files)+parallelBatchSize-1)/parallelBatchSize)
+	)
+
+	for start := 0; start < len(files); start += parallelBatchSize {
+		end := start + parallelBatchSize
+		if end > len(files) {
+			end = len(files)
+		}
+
+		batch := append([]string(nil), files[start:end]...)
+		wg.Add(1)
+		go func(batch []string) {
+			defer wg.Done()
+
+			args := append(append([]string(nil), baseArgs...), batch...)
+			cmd := exec.Command(rgPath, args...)
+			output, err := cmd.Output()
+
+			found := false
+			if err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) {
+					if exitErr.ExitCode() == 1 {
+						// No matches for this batch; still process the output below.
+					} else {
+						errChan <- fmt.Errorf("error executing ripgrep: %w", err)
+						return
+					}
+				} else {
+					errChan <- fmt.Errorf("error executing ripgrep: %w", err)
+					return
+				}
+			} else {
+				found = true
+			}
+
+			if !found && bytes.Contains(output, []byte(`"type":"match"`)) {
+				found = true
+			}
+
+			if consume != nil {
+				if err := consume(output); err != nil {
+					errChan <- err
+					return
+				}
+			}
+
+			if found {
+				matchesMu.Lock()
+				matchesFound = true
+				matchesMu.Unlock()
+			}
+		}(batch)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			return matchesFound, err
+		}
+	}
+
+	return matchesFound, nil
+}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -823,12 +823,14 @@ func authenticatedBubbleteaMiddleware() wish.Middleware {
 			for name, pubkey := range remote_users {
 				parsed, _, _, _, _ := ssh.ParseAuthorizedKey([]byte(pubkey))
 				if ssh.KeysEqual(s.PublicKey(), parsed) {
-					wish.Println(s, fmt.Sprintf("┗━━━┫ Authenticated as %s \n\n", name))
+					wish.Println(s, fmt.Sprintf("┗━━━┫ Authenticated as %s", name))
+					wish.Println(s, "")
 					bwish.Middleware(policyActionHandler)(next)(s)
 					return
 				}
 			}
-			wish.Println(s, "┗━━━┫ Authentication failed ╳ \n\n")
+			wish.Println(s, "┗━━━┫ Authentication failed ╳")
+			wish.Println(s, "")
 			s.Close()
 		}
 	}

--- a/cmd/status_handler.go
+++ b/cmd/status_handler.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "sync"
+
+var (
+	statusHandlerMu     sync.RWMutex
+	policyStatusHandler = func(Policy, bool) {}
+)
+
+// SetPolicyStatusHandler registers a handler invoked when an assure policy finishes executing.
+// Passing nil resets the handler to a no-op implementation.
+func SetPolicyStatusHandler(handler func(Policy, bool)) {
+	statusHandlerMu.Lock()
+	defer statusHandlerMu.Unlock()
+
+	if handler == nil {
+		policyStatusHandler = func(Policy, bool) {}
+		return
+	}
+
+	policyStatusHandler = handler
+}
+
+func reportPolicyStatus(policy Policy, matchesFound bool) {
+	statusHandlerMu.RLock()
+	handler := policyStatusHandler
+	statusHandlerMu.RUnlock()
+
+	handler(policy, matchesFound)
+}


### PR DESCRIPTION
## Summary
- add a shared runParallelRipgrep helper that detects actual matches while streaming batch output
- report assure execution results through a policy status handler and cover parallel batches with new tests
- tidy API status messages and SSH prompts flagged by go vet so go test ./... succeeds

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cab288b49c832496bfad4568dc4760

<!-- codii:summary:start -->
> [!IMPORTANT]
> The pull request refactors the `executeAssure` and `executeParallelAssure` functions for better clarity and performance, introduces a new `runParallelRipgrep` function to handle parallel execution, and adds tests for the `executeAssure` function to ensure correct behavior. Additionally, it improves logging and status reporting mechanisms.
> <sup>This description was created by </sup>[<img alt="Codii" src="https://img.shields.io/badge/codii-dev-blue">](https://codii.dev)<sup> for [5ab833f](https://github.com/xfhg/intercept/commit/5ab833f02c5c0f482b32c4bb56d4aeb27d7d8d76).</sup>
<!-- codii:summary:end -->